### PR TITLE
Post JSON params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
       - run:
           name: Execute test using JSON params
           command: |
-            docker network create temp-network
             docker run -d \
               --network temp-network \
               --name standalone-app-2 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
               echo "On branch $CIRCLE_BRANCH, nothing else to do."
             fi
 
+
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
               -e NGROK_TOKEN=$NGROK_TOKEN \
               -e GI_API_KEY=$GI_API_KEY \
               -e GI_SUITE=5a9f04539d311c32b43f49d6 \
-              -e GI_PARAMS_JSON='{"sha":"$CIRCLE_SHA1"}' \
+              -e GI_PARAMS_JSON='{"sha":"'$CIRCLE_SHA1'"}' \
               -e APP_PORT=standalone-app-2:8000 \
               --network temp-network \
               ghostinspector/test-runner-standalone:0.1.$CIRCLE_BUILD_NUM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
             else
               echo "On branch $CIRCLE_BRANCH, nothing else to do."
             fi
+
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             docker build -t standalone-app:0.1.$CIRCLE_BUILD_NUM ./test/standalone-app
       - run:
-          name: Execute test
+          name: Execute test using environment params
           command: |
             docker network create temp-network
             docker run -d \
@@ -70,6 +70,22 @@ jobs:
               -e GI_SUITE=5a9f04539d311c32b43f49d6 \
               -e GI_PARAM_sha=$CIRCLE_SHA1 \
               -e APP_PORT=standalone-app:8000 \
+              --network temp-network \
+              ghostinspector/test-runner-standalone:0.1.$CIRCLE_BUILD_NUM
+      - run:
+          name: Execute test using JSON params
+          command: |
+            docker network create temp-network
+            docker run -d \
+              --network temp-network \
+              --name standalone-app-2 \
+              standalone-app:0.1.$CIRCLE_BUILD_NUM --sha=$CIRCLE_SHA1
+            docker run \
+              -e NGROK_TOKEN=$NGROK_TOKEN \
+              -e GI_API_KEY=$GI_API_KEY \
+              -e GI_SUITE=5a9f04539d311c32b43f49d6 \
+              -e GI_PARAMS_JSON='{"sha":"$CIRCLE_SHA1"}' \
+              -e APP_PORT=standalone-app-2:8000 \
               --network temp-network \
               ghostinspector/test-runner-standalone:0.1.$CIRCLE_BUILD_NUM
       - run:

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -7,6 +7,9 @@ set -e
 : "${APP_PORT:?APP_PORT env var is required}"
 : ${STARTUP_DELAY:=3}
 
+# ability to provide extra params via JSON
+: ${GI_PARAMS_JSON:=''}
+
 # set TERM if not present, ngrok will fail with missing TERM
 : ${TERM:=xterm}
 
@@ -82,10 +85,25 @@ STATUS='null'
 SUITE_RESULT=
 PASSING=
 
+# Check for POST option
+POST_OPTION=''
+if [ $GI_PARAMS_JSON != '' ]; then
+  # validate the POST data
+  echo $GI_PARAMS_JSON | jq . > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    # not valid JSON
+    echo "Extra params data not valid JSON, exiting..."
+    exit 1
+  fi
+  # if we got here the data is good
+  POST_OPTION=" -XPOST -d'$GI_PARAMS_JSON'"
+  echo "JSON params specified, executing suite with $POST_OPTION"
+fi
+
 # Execute Ghost Inspector suite via API and grab the result ID
 EXECUTE_URL="https://api.ghostinspector.com/v1/suites/$GI_SUITE/execute/?startUrl=$START_URL&immediate=1$GI_EXTRA_PARAMS"
 echo "Executing suite: $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY"
-RESULT_ID=$(curl -s "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
+RESULT_ID=$(curl -s$POST_OPTION "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
 
 # for the suite result, sleep for a few seconds if it hasn't changed
 echo "Polling for suite results (ID: $RESULT_ID)"

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -89,7 +89,7 @@ PASSING=
 EXECUTE_URL="https://api.ghostinspector.com/v1/suites/$GI_SUITE/execute/?startUrl=$START_URL&immediate=1$GI_EXTRA_PARAMS"
 if [ $GI_PARAMS_JSON != '' ]; then
   echo "Executing suite (POST): $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY ($GI_PARAMS_JSON)"
-  RESULT_ID=$(curl -s -XPOST -H'Content-Type: application/json' -d'$GI_PARAMS_JSON' "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
+  RESULT_ID=$(curl -s -XPOST -H'Content-Type: application/json' -d''$GI_PARAMS_JSON'' "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
 else
   echo "Executing suite (GET): $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY"
   RESULT_ID=$(curl -s$POST_OPTION "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -96,7 +96,7 @@ if [ $GI_PARAMS_JSON != '' ]; then
     exit 1
   fi
   # if we got here the data is good
-  POST_OPTION=" -XPOST -d'$GI_PARAMS_JSON'"
+  POST_OPTION=" -XPOST -H'Content-Type: application/json' -d'$GI_PARAMS_JSON'"
   echo "JSON params specified, executing suite with $POST_OPTION"
 fi
 

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -85,25 +85,15 @@ STATUS='null'
 SUITE_RESULT=
 PASSING=
 
-# Check for POST option
-POST_OPTION=''
-if [ $GI_PARAMS_JSON != '' ]; then
-  # validate the POST data
-  echo $GI_PARAMS_JSON | jq . > /dev/null 2>&1
-  if [ $? -ne 0 ]; then
-    # not valid JSON
-    echo "Extra params data not valid JSON, exiting..."
-    exit 1
-  fi
-  # if we got here the data is good
-  POST_OPTION=" -XPOST -H'Content-Type: application/json' -d'$GI_PARAMS_JSON'"
-  echo "JSON params specified, executing suite with $POST_OPTION"
-fi
-
 # Execute Ghost Inspector suite via API and grab the result ID
 EXECUTE_URL="https://api.ghostinspector.com/v1/suites/$GI_SUITE/execute/?startUrl=$START_URL&immediate=1$GI_EXTRA_PARAMS"
-echo "Executing suite: $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY"
-RESULT_ID=$(curl -s$POST_OPTION "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
+if [ $GI_PARAMS_JSON != '' ]; then
+  echo "Executing suite (POST): $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY ($GI_PARAMS_JSON)"
+  RESULT_ID=$(curl -s -XPOST -H'Content-Type: application/json' -d'$GI_PARAMS_JSON' "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
+else
+  echo "Executing suite (GET): $EXECUTE_URL&apiKey=$PRINT_GI_API_KEY"
+  RESULT_ID=$(curl -s$POST_OPTION "$EXECUTE_URL&apiKey=$GI_API_KEY" | jq -r '.data._id')
+fi
 
 # for the suite result, sleep for a few seconds if it hasn't changed
 echo "Polling for suite results (ID: $RESULT_ID)"


### PR DESCRIPTION
Adds ability to `POST` JSON params within either of the docker test runners, as an alternative to `GI_PARAM_myParam`, you can now use `GI_PARAMS_JSON='{"my":"json"}'`. 

I added this to make our "interface" for the CircleCI orbs consistent between the basic commands and the ones that will use docker.