### PR TITLE
add ability to fail based on screenshotComparePassing

### DIFF
--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -10,6 +10,9 @@ set -e
 # ability to provide extra params via JSON
 : ${GI_PARAMS_JSON:=''}
 
+# ability to use screenshot to pass/fail test
+: ${GI_PASSING_STATUS_KEY:='passing'}
+
 # set TERM if not present, ngrok will fail with missing TERM
 : ${TERM:=xterm}
 
@@ -21,6 +24,7 @@ echo "NGROK_TOKEN: $PRINT_NGROK_TOKEN"
 echo "GI_API_KEY: $PRINT_GI_API_KEY"
 echo "GI_SUITE: $GI_SUITE"
 echo "APP_PORT: $APP_PORT"
+echo "PASSING_STATUS_KEY: $GI_PASSING_STATUS_KEY"
 
 # check for additional URL parameters in the environment
 set +e
@@ -100,16 +104,16 @@ echo "Polling for suite results (ID: $RESULT_ID)"
 while [ "$STATUS" = 'null' ]; do
   sleep 5
   SUITE_RESULT=$(curl -s "https://api.ghostinspector.com/v1/suite-results/$RESULT_ID/?apiKey=$GI_API_KEY")
-  STATUS=$(echo $SUITE_RESULT | jq -r '.data.passing')
+  STATUS=$(echo $SUITE_RESULT | jq -r '.data.'$GI_PASSING_STATUS_KEY'')
   if [ "$STATUS" = 'null' ]; then
     echo " - status: running..."
   else
-    echo " - status: done, passing: $STATUS"
+    echo " - status: done, $GI_PASSING_STATUS_KEY: $STATUS"
   fi
 done
 
 # status has been updated, check results for "passing"
-if [ "$(echo $SUITE_RESULT | jq -r '.data.passing')" != 'true' ]; then
+if [ "$(echo $SUITE_RESULT | jq -r '.data.'$GI_PASSING_STATUS_KEY'')" != 'true' ]; then
   echo "Suite failed! ¯\_(ツ)_/¯"
   PASSING=1
 else 

--- a/test-runner-node/README.md
+++ b/test-runner-node/README.md
@@ -64,6 +64,7 @@ runner:
  * `NGROK_TOKEN` - available from your [ngrok account](https://ngrok.com/)
  * `STARTUP_DELAY` (optional) - seconds to wait for application and ngrok each to start up, defaults to 3 seconds
  * `GI_PARAM_myVar` (optional) - additional URL parameter to send to our API, the value of which will be accessible in your test under `{{myVar}}`
+ * `GI_PASSING_STATUS_KEY` (optional) - set this to `screenshotComparePassing` if you wish to fail the build based on the screenshot status.
 
 ### Entry point
 The last line of your `Dockerfile` should be `CMD`, which should look

--- a/test-runner-standalone/README.md
+++ b/test-runner-standalone/README.md
@@ -67,7 +67,7 @@ to the same `test-network` so all the DNS and networking magic can happen. Also
 note that you can send custom variables to the API call when we execute your
 test suite by using a custom environment variable named `GI_PARAM_varName`
 where `varName` is the name of your variable. This will be available in your
-Ghost Inspector tests under `{{varName}}` at runtime.
+Ghost Inspector tests under `{{varName}}` at runtime. Finally, if you wish to have the build status based on the screenshot instead, you may want to add an environment variable for `GI_PASSING_STATUS_KEY` with a value of `screenshotComparePassing`.
 
 Once this container fires up, it will perform the exact same set of actions as
 before:


### PR DESCRIPTION
[A customer asked for the feature](https://app.intercom.io/a/apps/c4u9yg3e/inbox/inbox/1559446/conversations/22027790841), adds the ability to pass/fail the suite based on `screenshotComparePassing` instead of the regular `passing` status.