### PR TITLE
Add run test script

### DIFF
--- a/includes/bin/run-test.js
+++ b/includes/bin/run-test.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const assert = require('assert')
+
+function usageAndExit() {
+  console.log(`Usage: ./run-test.js test-id '{"json": "params"}'`)
+  process.exit(1)
+}
+
+async function main(testId, params='{}') {
+  console.log('Params:', params)
+  params = JSON.parse(params)
+
+  // set up the client
+  const apiKey = process.env.GI_API_KEY
+  assert.ok(apiKey, 'GI_API_KEY must be present in the environment')
+  const ghost = require('ghost-inspector')(apiKey)
+
+  // validate the suite
+  try {
+    assert.ok(String(testId).match(/^[a-f\d]{24}$/))
+  } catch (unused) {
+    usageAndExit()
+  }
+
+  const [unused, passing, screenshotPassing] = await ghost.executeTest(testId, params);
+  console.log('Got result:')
+  console.log(' -> passing:', passing)
+  console.log(' -> screenshotPassing', screenshotPassing)
+
+  if (params.passingStatusKey === 'screenshotComparePassing') {
+    return passing && screenshotPassing
+  } else {
+    return passing
+  }
+}
+
+main(process.argv[2], process.argv[3]).then((passing) => {
+  if (passing) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
+}).catch((error) => {
+  console.error('Error executing test:', error.message)
+  process.exit(1)
+})

--- a/test-runner-standalone/Dockerfile
+++ b/test-runner-standalone/Dockerfile
@@ -20,8 +20,9 @@ RUN chmod +x /bin/jq
 # Install the Ghost Inspector client.
 RUN npm install ghost-inspector
 
-# Add the files that will run the test suite.
+# Add GI executables.
 COPY ./includes/bin/run-suite.js /bin/run-suite.js
+COPY ./includes/bin/run-test.js /bin/run-test.js
 COPY ./includes/bin/runghostinspectorsuite /bin/runghostinspectorsuite
 
 # add our user
@@ -33,4 +34,4 @@ WORKDIR /home/ghostinspector
 EXPOSE 4040
 
 # The primary script.
-ENTRYPOINT ["/bin/runghostinspectorsuite"]
+CMD ["/bin/runghostinspectorsuite"]


### PR DESCRIPTION
This adjusts the `ghost-inspector/test-runner-standalone` image as a bit of a stopgap until we have an official CLI build.  The changes are:

#### 1. Add test execution script

There is another (duplicate) script for test execution now at `/bin/run-test.js`. I could have adjusted the existing script to handle both tests and suites, but since it's tested and published I opted to not adjust it.

#### 2. Adjust entrypoint

These images were originally set up with `ENTRYPOINT ["/bin/runghostinspectorsuite"]` which effectively means when you run the docker image like this...

```
docker run ghost-inspector/test-runner-standalone foo-bar-baz
```

.. internally those arguments are executed like so:

```
/bin/runghostinspectorsuite foo-bar-baz
```

This is expected on the `ghost-inspector/test-runner-node` image since users should be passing in the path to their Node.js application entry point (eg: `app.js`), but for the `test-runner-standalone` this is not really used. By making the change to `CMD` the internal execution now looks like:

```
/bin/bash /bin/runghostinspectorsuite
```

For this standalone image this should have no effect on the existing usage, but will allow us to utilize this image in other places (such as CircleCI orbs for the time being) by executing the container like so:

```
docker run ghost-inspector/test-runner-standalone /bin/run-suite.js <suiteId> '{"my": "params"}'
```