### PR TITLE
Add APP_WAIT_TIMEOUT, for slow-starting apps in other containers

### DIFF
--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -22,7 +22,7 @@ set -e
 : ${TERM:=xterm}
 
 # prepend hostname to APP_PORT if not given - for wget below:
-if [ "$APP_PORT" -ge 0 ]; then
+if [ "$APP_PORT" -ge 0 ] 2>/dev/null; then
 	APP_PORT="localhost:$APP_PORT"
 fi
 

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -8,6 +8,9 @@ set -e
 : "${GI_API_KEY:?GI_API_KEY env var is required}"
 : "${APP_PORT:?APP_PORT env var is required}"
 : ${STARTUP_DELAY:=3}
+: ${APP_WAIT_TIMEOUT:=}
+: ${APP_WAIT_DELAY:=5}
+
 
 # ability to provide extra params via JSON
 : ${GI_PARAMS_JSON:='{}'}
@@ -17,6 +20,11 @@ set -e
 
 # set TERM if not present, ngrok will fail with missing TERM
 : ${TERM:=xterm}
+
+# prepend hostname to APP_PORT if not given - for wget below:
+if [ "$APP_PORT" -ge 0 ]; then
+	APP_PORT="localhost:$APP_PORT"
+fi
 
 # obscure sensitive tokens from output
 PRINT_NGROK_TOKEN="$(echo $NGROK_TOKEN | head -c4)****************"
@@ -95,6 +103,22 @@ echo "Using start URL: $START_URL"
 # Inject the start url
 GI_PARAMS_JSON=$(echo "$GI_PARAMS_JSON" | jq --arg startUrl "$START_URL" '. + {startUrl: $startUrl}')
 echo "Using JSON params: $GI_PARAMS_JSON"
+
+# wait for app to be up:
+if [ -n "$APP_WAIT_TIMEOUT" ]; then
+  : $((APP_WAIT_RETRIES=$APP_WAIT_TIMEOUT/$APP_WAIT_DELAY))
+  APP_WAIT_TRY=1
+  until wget -t1 -T1 -q --max-redirect=2 $APP_PORT || [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ]; do
+    echo "Waiting for $APP_PORT before running test suite... ($APP_WAIT_TRY/$APP_WAIT_RETRIES)"
+    : $((APP_WAIT_TRY=$APP_WAIT_TRY+1))
+    sleep $APP_WAIT_DELAY
+  done
+  if [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ]; then
+    echo "$APP_PORT was not available in time"
+    exit 1
+  fi
+  echo "$APP_PORT is up, running test..."
+fi
 
 # Execute the suite
 set +e

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -108,7 +108,7 @@ echo "Using JSON params: $GI_PARAMS_JSON"
 if [ -n "$APP_WAIT_TIMEOUT" ]; then
   : $((APP_WAIT_RETRIES=$APP_WAIT_TIMEOUT/$APP_WAIT_DELAY))
   APP_WAIT_TRY=1
-  until [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ] || wget -t5 -T1 -q --max-redirect=0 $APP_PORT || [ "$?" -ge 5 ]; do
+  until [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ] || wget -t1 -T$APP_WAIT_DELAY -q --max-redirect=0 $APP_PORT || [ "$?" -ge 5 ]; do
     echo "Waiting for $APP_PORT before running test suite... (check $APP_WAIT_TRY of $APP_WAIT_RETRIES)"
     : $((APP_WAIT_TRY=$APP_WAIT_TRY+1))
     sleep $APP_WAIT_DELAY

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -108,8 +108,8 @@ echo "Using JSON params: $GI_PARAMS_JSON"
 if [ -n "$APP_WAIT_TIMEOUT" ]; then
   : $((APP_WAIT_RETRIES=$APP_WAIT_TIMEOUT/$APP_WAIT_DELAY))
   APP_WAIT_TRY=1
-  until wget -t1 -T1 -q --max-redirect=2 $APP_PORT || [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ]; do
-    echo "Waiting for $APP_PORT before running test suite... ($APP_WAIT_TRY/$APP_WAIT_RETRIES)"
+  until [ $APP_WAIT_TRY -eq $APP_WAIT_RETRIES ] || wget -t5 -T1 -q --max-redirect=0 $APP_PORT || [ "$?" -ge 5 ]; do
+    echo "Waiting for $APP_PORT before running test suite... (check $APP_WAIT_TRY of $APP_WAIT_RETRIES)"
     : $((APP_WAIT_TRY=$APP_WAIT_TRY+1))
     sleep $APP_WAIT_DELAY
   done


### PR DESCRIPTION
## Background

We use test-runner-standalone as a service container to run tests against a Magento container, which takes 1-2 minutes to start up.  By default, the test runner starts immediately and expects the app to be available. This allows setting APP_WAIT_TIMEOUT, which defaults to off for backwards compatibility.

Adding this allows the ghostinspector/test-runner-standalone to be used a service container in a docker-compose or bitbucket pipeline setup - key points are:
* your main app container should use a script like `wait-for-it.sh` to wait for port 4040 to become available on the ghostinspector container - eg. `wait-for-it.sh ghost:4040 -t 30` at the top of your entrypoint script
* the ghostinspector container will start the ngrok tunnel, then wait for your app to become available

## In action:
![image](https://user-images.githubusercontent.com/2004038/112722390-31500880-8f01-11eb-9ea8-d9e09aa9dc56.png)

## Notes:
* using wget, since its already available, rather than installing more packages
* the code could be as simple as `wget -t12 -T5 --no-verbose --retry-connrefused $APP_PORT` to achieve a similar effect, but the output is not friendly

## Example docker-compose setup:
```
services:
  mysql:
    image: mariadb:10.4
    environment:
      ALLOW_EMPTY_PASSWORD: '1'
      MYSQL_USER: 'dbuser'
      MYSQL_PASSWORD: 'dbpass'
      MYSQL_DATABASE: 'dbname'
      MYSQL_ROOT_PASSWORD: 'dbpass'
  elastic:
    image: getjohn/elasticsearch-docker:7.11.2
    environment:
      ES_JAVA_OPTS: "-Xms256m -Xmx256m"
  ghost:
    image: ghostinspector/test-runner-standalone
    environment:
      NGROK_TOKEN: $NGROK_TOKEN
      GI_API_KEY: $GI_API_KEY
      GI_SUITE: 'xxxxxxxxxxxxxxxxxxxxxx'
      APP_PORT: 'magento:80'
      APP_WAIT_TIMEOUT: 180
  magento:
    image: magentotester:latest
    ports:
      - '80:80'
    depends_on:
      - 'ghost'
      - 'mysql'
      - 'elastic'
    environment:
      . . . etc . . .
```

## Example entrypoint script

(so this would be in *your* container, which runs your app (eg. magento in our case!), then waits for the ghostinspector test to finish, before exiting)

```
# Note - the container we use this in is based on the php:7.4-fpm image

set -e
# export any variables that we set in this script:
set -o allexport

# Discover the public URL - give the ghostinspector container time to come online:
: "${GJ_NGROK_HOST:=127.0.0.1:4040}"
wait-for-it.sh $GJ_NGROK_HOST -t ${GJ_NGROK_WAIT:=30}
GJ_WEBSITE_URL=$(curl -s 'http://'$GJ_NGROK_HOST'/api/tunnels' | jq -r '.tunnels[1].public_url' | sed 's/http:/https:/')
: ${GJ_WEBSITE_URL:?Could not get public URL from ngrok on $GJ_NGROK_HOST}

echo "Waiting for Elasticsearch and MySQL to start..."
wait-for-it.sh $MYSQL_HOST:3306 -t $GJ_SERVICES_WAIT
wait-for-it.sh $GJ_ELASTIC_HOST:9200 -t $GJ_SERVICES_WAIT

# database setup goes here...

magerun2 config:set --scope=default catalog/search/elasticsearch7_server_hostname $GJ_ELASTIC_HOST
magerun2 config:set --scope=website --scope-code=$GJ_WEBSITE_CODE web/unsecure/base_url $GJ_WEBSITE_URL
magerun2 config:set --scope=website --scope-code=$GJ_WEBSITE_CODE web/secure/base_url $GJ_WEBSITE_URL

# other setup goes here...

echo "Starting nginx..."
nginx
echo "Running php-fpm in background"
php-fpm &

# now wait for ghostinspector test to finish: (wait til the ngrok port closes)

echo -n "Waiting for test to finish...."
while wait-for-it.sh $GJ_NGROK_HOST -q -t 5; do
        echo -n .
        sleep 5
done
echo "Finished!"
```

