### PR TITLE
adds CLI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,39 @@ jobs:
               echo "On branch $CIRCLE_BRANCH, nothing else to do."
             fi
 
+  build-cli-image:
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Build ghostinspector/cli
+          command: |
+            IMAGE_ID=$(docker build -q -t ghostinspector/cli ./cli)
+            docker tag $IMAGE_ID ghostinspector/cli:0.1.$CIRCLE_BUILD_NUM
+      - run:
+          name: Confirm build
+          command: |
+            docker run \
+              ghostinspector/cli:0.1.$CIRCLE_BUILD_NUM --version
+      - run:
+          name: Push new ghostinspector/cli image to Docker Hub
+          command: |
+            if [ $CIRCLE_BRANCH = 'stable' ]; then
+              echo "Pushing new image to Docker Hub"
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push ghostinspector/cli:0.1.$CIRCLE_BUILD_NUM
+              docker push ghostinspector/cli:latest
+            else
+              echo "On branch $CIRCLE_BRANCH, nothing else to do."
+            fi
 
 workflows:
   version: 2
   test:
     jobs:
+      - build-cli-image
       - build-and-test-base-image
       - build-and-test-standalone-image:
           requires:

--- a/build
+++ b/build
@@ -5,15 +5,15 @@ DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ARGS=$1
 
-IMGS=${ARGS:=node standalone} 
+IMGS=${ARGS:=cli test-runner-node test-runner-standalone} 
 echo "Building image(s): $IMGS"
 for img in $IMGS; do
   echo ""
-  echo "Building ghostinspector/test-runner-$img..."
+  echo "Building ghostinspector/$img..."
   # docker cannot see outside of it's current context, copy dependencies temporarily
-  cp -R $DIR/includes/ $DIR/test-runner-$img/includes
-  cd $DIR/test-runner-$img && docker build -t ghostinspector/test-runner-$img .
-  rm -R $DIR/test-runner-$img/includes
+  cp -R $DIR/includes/ $DIR/$img/includes
+  cd $DIR/$img && docker build -t ghostinspector/$img .
+  rm -R $DIR/$img/includes
   echo "Done."
 done
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:12
+MAINTAINER Ghost Inspector <help@ghostinspector.com>
+
+# Install jq.
+ADD http://stedolan.github.io/jq/download/linux64/jq /bin/jq
+RUN chmod +x /bin/jq
+
+# Install the Ghost Inspector client.
+RUN npm install -g ghost-inspector
+
+# The primary script.
+ENTRYPOINT ["/usr/local/bin/ghost-inspector"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,49 @@
+## Ghost Inspector CLI Docker image
+
+This image is provided as a convenience image for working with the [Ghost Inspector CLI](https://ghostinspector.com/docs/api/cli/).
+
+# Quickstart
+
+```
+# execute a test, wait for completion
+docker run ghostinspector/cli test execute <testId> \
+  --startUrl "https://mysite.com" \
+  --myVariable superduper \
+  --failOnError
+```
+
+For a full list of commands, run `--help`
+
+```
+docker run ghostinspector/cli --help
+```
+
+# LICENSE
+
+```
+The MIT License
+
+Copyright (c) Ghost Inspector, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+# Support
+
+Please open [issues in Github](https://github.com/ghost-inspector/docker-test-runner/issues) or send questions to [Ghost Inspector support](https://ghostinspector.com/support/)

--- a/test-runner-standalone/Dockerfile
+++ b/test-runner-standalone/Dockerfile
@@ -15,7 +15,7 @@ ADD http://stedolan.github.io/jq/download/linux64/jq /bin/jq
 RUN chmod +x /bin/jq
 
 # Install the Ghost Inspector client.
-RUN npm install ghost-inspector
+RUN npm install -g ghost-inspector
 
 # Add GI executables.
 COPY ./includes/bin/run-suite.js /bin/run-suite.js

--- a/test-runner-standalone/Dockerfile
+++ b/test-runner-standalone/Dockerfile
@@ -15,7 +15,7 @@ ADD http://stedolan.github.io/jq/download/linux64/jq /bin/jq
 RUN chmod +x /bin/jq
 
 # Install the Ghost Inspector client.
-RUN npm install -g ghost-inspector
+RUN npm install ghost-inspector
 
 # Add GI executables.
 COPY ./includes/bin/run-suite.js /bin/run-suite.js


### PR DESCRIPTION
This change adds a new docker image for CLI, which should help us fix an issue with our [CircleCI orb commands](https://github.com/ghost-inspector/circleci-orbs/blob/stable/orb.yml#L101) that need to be updated due to recent API changes. This will need to be merged down [after the latest CLI changes](https://github.com/ghost-inspector/node-ghost-inspector/pull/33/files)