### PR TITLE
Add app startup delay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
               -e GI_PARAM_build=$CIRCLE_BUILD_NUM \
               -e GI_PARAMS_JSON='{"jsonParam": "my-json-param"}' \
               -e APP_PORT=8000 \
+              -e APP_WAIT_TIMEOUT=3 \
               -e MY_ENV_VAR=my-env-var \
               node-app:0.1.$CIRCLE_BUILD_NUM index.js --sha=$CIRCLE_SHA1 --build=$CIRCLE_BUILD_NUM
       - run:
@@ -71,6 +72,7 @@ jobs:
               -e GI_SUITE=5a9f04539d311c32b43f49d6 \
               -e GI_PARAM_sha=$CIRCLE_SHA1 \
               -e APP_PORT=standalone-app:8000 \
+              -e APP_WAIT_TIMEOUT=3 \
               -e GI_PARAMS_JSON='{"jsonParam": "my-json-param"}' \
               --network temp-network \
               ghostinspector/test-runner-standalone:0.1.$CIRCLE_BUILD_NUM

--- a/build
+++ b/build
@@ -5,7 +5,8 @@ DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ARGS=$1
 
-IMGS=${ARGS:=cli test-runner-node test-runner-standalone} 
+# IMGS=${ARGS:=cli test-runner-node test-runner-standalone} 
+IMGS=${ARGS:=test-runner-standalone} 
 echo "Building image(s): $IMGS"
 for img in $IMGS; do
   echo ""

--- a/build
+++ b/build
@@ -5,8 +5,7 @@ DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ARGS=$1
 
-# IMGS=${ARGS:=cli test-runner-node test-runner-standalone} 
-IMGS=${ARGS:=test-runner-standalone} 
+IMGS=${ARGS:=cli test-runner-node test-runner-standalone} 
 echo "Building image(s): $IMGS"
 for img in $IMGS; do
   echo ""
@@ -17,5 +16,3 @@ for img in $IMGS; do
   rm -R $DIR/$img/includes
   echo "Done."
 done
-
-# main $1

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -21,7 +21,7 @@ set -e
 
 # prepend hostname to APP_PORT if not specified
 if [ "$APP_PORT" -ge 0 ] 2>/dev/null; then
-	APP_PORT="localhost:$APP_PORT"
+  APP_PORT="localhost:$APP_PORT"
 fi
 
 # obscure sensitive tokens from output

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -8,6 +8,8 @@ set -e
 : "${GI_API_KEY:?GI_API_KEY env var is required}"
 : "${APP_PORT:?APP_PORT env var is required}"
 : ${STARTUP_DELAY:=3}
+: ${APP_WAIT_TIMEOUT:=}
+: ${APP_WAIT_DELAY:=5}
 
 # ability to provide extra params via JSON
 : ${GI_PARAMS_JSON:='{}'}
@@ -17,6 +19,11 @@ set -e
 
 # set TERM if not present, ngrok will fail with missing TERM
 : ${TERM:=xterm}
+
+# prepend hostname to APP_PORT if not specified
+if [ "$APP_PORT" -ge 0 ] 2>/dev/null; then
+	APP_PORT="localhost:$APP_PORT"
+fi
 
 # obscure sensitive tokens from output
 PRINT_NGROK_TOKEN="$(echo $NGROK_TOKEN | head -c4)****************"
@@ -95,6 +102,12 @@ echo "Using start URL: $START_URL"
 # Inject the start url
 GI_PARAMS_JSON=$(echo "$GI_PARAMS_JSON" | jq --arg startUrl "$START_URL" '. + {startUrl: $startUrl}')
 echo "Using JSON params: $GI_PARAMS_JSON"
+
+# Wait for application startup, if specified
+if [ -n "$APP_WAIT_TIMEOUT" ]; then
+  /bin/wait-for-it $APP_PORT -t $APP_WAIT_TIMEOUT
+  echo "$APP_PORT is up, continuing..."
+fi
 
 # Execute the suite
 set +e

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -8,8 +8,7 @@ set -e
 : "${GI_API_KEY:?GI_API_KEY env var is required}"
 : "${APP_PORT:?APP_PORT env var is required}"
 : ${STARTUP_DELAY:=3}
-: ${APP_WAIT_TIMEOUT:=30}
-: ${APP_WAIT_DELAY:=5}
+: ${APP_WAIT_TIMEOUT:=}
 
 # ability to provide extra params via JSON
 : ${GI_PARAMS_JSON:='{}'}
@@ -105,7 +104,6 @@ echo "Using JSON params: $GI_PARAMS_JSON"
 
 # Wait for application startup, if specified
 if [ -n "$APP_WAIT_TIMEOUT" ]; then
-  echo "Waiting for app response at $APP_PORT (timeout after $APP_WAIT_TIMEOUT)"
   /usr/bin/wait-for-it $APP_PORT -t $APP_WAIT_TIMEOUT
   echo "$APP_PORT is up, continuing..."
 fi

--- a/includes/bin/runghostinspectorsuite
+++ b/includes/bin/runghostinspectorsuite
@@ -8,7 +8,7 @@ set -e
 : "${GI_API_KEY:?GI_API_KEY env var is required}"
 : "${APP_PORT:?APP_PORT env var is required}"
 : ${STARTUP_DELAY:=3}
-: ${APP_WAIT_TIMEOUT:=}
+: ${APP_WAIT_TIMEOUT:=30}
 : ${APP_WAIT_DELAY:=5}
 
 # ability to provide extra params via JSON
@@ -105,7 +105,8 @@ echo "Using JSON params: $GI_PARAMS_JSON"
 
 # Wait for application startup, if specified
 if [ -n "$APP_WAIT_TIMEOUT" ]; then
-  /bin/wait-for-it $APP_PORT -t $APP_WAIT_TIMEOUT
+  echo "Waiting for app response at $APP_PORT (timeout after $APP_WAIT_TIMEOUT)"
+  /usr/bin/wait-for-it $APP_PORT -t $APP_WAIT_TIMEOUT
   echo "$APP_PORT is up, continuing..."
 fi
 

--- a/test-runner-node/Dockerfile
+++ b/test-runner-node/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:12
 MAINTAINER Ghost Inspector <help@ghostinspector.com>
 
+# Install wait-for-it
+RUN apt-get update \
+  && apt-get install -y wait-for-it \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install unzip
 RUN wget -qO- https://oss.oracle.com/el4/unzip/unzip.tar | tar -x -C /bin/
 

--- a/test-runner-node/README.md
+++ b/test-runner-node/README.md
@@ -1,5 +1,4 @@
-Ghost Inspector test runner Docker images
------------------------------------------
+## Ghost Inspector test runner Docker images
 
 **Build status**: ![build status](https://circleci.com/gh/ghost-inspector/docker-test-runner/tree/stable.svg?style=shield&circle-token=245dca7e57995c5746b1fdb43ed8d645a6c8aa81)
 
@@ -14,10 +13,10 @@ against your local Docker application.
 There is also a standalone, multi-container Docker image available
 [here](https://hub.docker.com/r/ghostinspector/test-runner-standalone/).
 
+# Quickstart
 
-Quickstart
-==========
 Example `Dockerfile`:
+
 ```
 FROM ghostinspector/test-runner-node
 
@@ -44,29 +43,32 @@ $ docker build -t my-app .
 $ docker run my-app
 ```
 
-Base Docker Image
------------------
+## Base Docker Image
+
 This image is intended to be the base image for your application under test,
 meaning that the application runtime and Ghost Inspector scripts and utilities
-are pre-installed for you. 
+are pre-installed for you.
 
 To get started, specify `ghostinspector/test-runner-node` in the `FROM`
 section of your `Dockerfile`.
 
 ### Environment variables
+
 As well as adding any dependencies or additional requirements for your
 application, the following environment variables are required for the test
 runner:
 
- * `APP_PORT` - the port your local application will run on (eg: `3000`)
- * `GI_API_KEY` - available in your [Ghost Inspector account](https://app.ghostinspector.com/account)
- * `GI_SUITE` - the ID of the Ghost Inspector test suite you wish to run
- * `NGROK_TOKEN` - available from your [ngrok account](https://ngrok.com/)
- * `STARTUP_DELAY` (optional) - seconds to wait for application and ngrok each to start up, defaults to 3 seconds
- * `GI_PARAM_myVar` (optional) - additional URL parameter to send to our API, the value of which will be accessible in your test under `{{myVar}}`
- * `GI_PASSING_STATUS_KEY` (optional) - set this to `screenshotComparePassing` if you wish to fail the build based on the screenshot status.
+- `APP_PORT` - the port your local application will run on (eg: `3000`)
+- `GI_API_KEY` - available in your [Ghost Inspector account](https://app.ghostinspector.com/account)
+- `GI_SUITE` - the ID of the Ghost Inspector test suite you wish to run
+- `NGROK_TOKEN` - available from your [ngrok account](https://ngrok.com/)
+- `STARTUP_DELAY` (optional) - seconds to wait for ngrok to start up, defaults to 3 seconds
+- `APP_WAIT_TIMEOUT` (optional) - ping `APP_PORT` for the specified number of seconds before execution, time out otherwise
+- `GI_PARAM_myVar` (optional) - additional URL parameter to send to our API, the value of which will be accessible in your test under `{{myVar}}`
+- `GI_PASSING_STATUS_KEY` (optional) - set this to `screenshotComparePassing` if you wish to fail the build based on the screenshot status.
 
 ### Entry point
+
 The last line of your `Dockerfile` should be `CMD`, which should look
 something like this:
 
@@ -78,15 +80,14 @@ CMD ["index.js", "--foo=bar"]
 [test runner script](includes/bin/runghostinspectorsuite) will perform the
 following:
 
- * start the entrypoint specified in `CMD` (eg: `index.js`) with `node`
- * start the `ngrok` daemon and open a tunnel to `localhost:PORT`
- * execute the Ghost Inspector test suite based on `GI_SUITE`
- * poll the Ghost Inspector API for `passing` status until a result is provided
- * exit with the pass (`0`) or fail (`1`) status
+- start the entrypoint specified in `CMD` (eg: `index.js`) with `node`
+- start the `ngrok` daemon and open a tunnel to `localhost:PORT`
+- execute the Ghost Inspector test suite based on `GI_SUITE`
+- poll the Ghost Inspector API for `passing` status until a result is provided
+- exit with the pass (`0`) or fail (`1`) status
 
+# LICENSE
 
-LICENSE
-=======
 ```
 The MIT License
 
@@ -111,6 +112,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-Support
-=======
+# Support
+
 Please open [issues in Github](https://github.com/ghost-inspector/docker-test-runner/issues) or send questions to [Ghost Inspector support](https://ghostinspector.com/support/)

--- a/test-runner-standalone/Dockerfile
+++ b/test-runner-standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:12
 MAINTAINER Ghost Inspector <help@ghostinspector.com>
 
 # Install wait-for-it

--- a/test-runner-standalone/Dockerfile
+++ b/test-runner-standalone/Dockerfile
@@ -1,5 +1,10 @@
-FROM node:12
+FROM node:14
 MAINTAINER Ghost Inspector <help@ghostinspector.com>
+
+# Install wait-for-it
+RUN apt-get update \
+  && apt-get install -y wait-for-it \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install unzip
 RUN wget -qO- https://oss.oracle.com/el4/unzip/unzip.tar | tar -x -C /bin/

--- a/test-runner-standalone/README.md
+++ b/test-runner-standalone/README.md
@@ -1,5 +1,4 @@
-Ghost Inspector test runner Docker images
------------------------------------------
+## Ghost Inspector test runner Docker images
 
 **Build status**: ![build status](https://circleci.com/gh/ghost-inspector/docker-test-runner/tree/stable.svg?style=shield&circle-token=245dca7e57995c5746b1fdb43ed8d645a6c8aa81)
 
@@ -14,10 +13,10 @@ against another running Docker container within your cluster.
 There is also single-container Docker image available
 [here](https://hub.docker.com/r/ghostinspector/test-runner-node/).
 
-Multi-container test runner
----------------------------
+## Multi-container test runner
+
 Even in more complex scenarios it is still possible to test your application
-through the magic of Docker by using the 
+through the magic of Docker by using the
 `ghost-inspector/test-runner-standalone` image and
 [Docker container networking](https://docs.docker.com/v17.09/engine/userguide/networking/).
 
@@ -43,7 +42,7 @@ $ docker run -d --name my-app --network test-network <my-image>
 ```
 
 Here we have named the new container `my-app` and connected it to the network
-`test-network`. Once that's up and running, we can fire up the Ghost Inspector 
+`test-network`. Once that's up and running, we can fire up the Ghost Inspector
 `test-runner-standalone` container which will run our suite against our running
 app:
 
@@ -54,6 +53,7 @@ $ docker run \
   -e GI_SUITE=<my-suite-id> \
   -e GI_PARAM_myVar=foo \
   -e APP_PORT=my-app:8000 \
+  -e APP_WAIT_TIMEOUT=15 \
   --network test-network \
   ghostinspector/test-runner-standalone
 ```
@@ -62,7 +62,9 @@ Make sure you change out all the environment variables to your own custom
 values for `NGROK_TOKEN`, `GI_API_KEY`, and `GI_SUITE`. Notice that for
 `APP_PORT` we've passed in `my-app:8000`, `my-app` will resolve to our running
 docker container that we named `my-app` and `8000` assumes that is the port
-that our application is running on. Finally we also connect this new container
+that our application is running on. We've also specified an `APP_WAIT_TIMEOUT`
+which will ping `my-app:8000` for up to `15` seconds before executing our suite.
+Finally we also connect this new container
 to the same `test-network` so all the DNS and networking magic can happen. Also
 note that you can send custom variables to the API call when we execute your
 test suite by using a custom environment variable named `GI_PARAM_varName`
@@ -72,13 +74,13 @@ Ghost Inspector tests under `{{varName}}` at runtime. Finally, if you wish to ha
 Once this container fires up, it will perform the exact same set of actions as
 before:
 
- * start the `ngrok` daemon and open a tunnel to `my-app:8000`
- * execute the Ghost Inspector test suite based on `GI_SUITE`
- * poll the Ghost Inspector API for `passing` status until a result is provided
- * exit with the pass (`0`) or fail (`1`) status
+- start the `ngrok` daemon and open a tunnel to `my-app:8000`
+- execute the Ghost Inspector test suite based on `GI_SUITE`
+- poll the Ghost Inspector API for `passing` status until a result is provided
+- exit with the pass (`0`) or fail (`1`) status
 
-LICENSE
-=======
+# LICENSE
+
 ```
 The MIT License
 
@@ -103,6 +105,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-Support
-=======
+# Support
+
 Please open issues in Github or send questions to [Ghost Inspector support](https://ghostinspector.com/support/)


### PR DESCRIPTION
As an alternative to https://github.com/ghost-inspector/docker-test-runner/pull/14 this change adds a package `wait-for-it` to the execution images, and an additional option when executing:

```
$ docker run \
  -e APP_WAIT_TIMEOUT=15 \
  ...
  ghostinspector/test-runner-standalone
```

This will invoke `wait-for-it` which is a simple command that will continually ping the app under test for the specified amount of time, exiting with a failure after the timeout; disabled by default.


